### PR TITLE
packages/jaeger-ui/src/components/TracePage/TraceStatistics/generateColor.test.js

### DIFF
--- a/packages/jaeger-ui/src/components/TracePage/TraceStatistics/generateColor.test.js
+++ b/packages/jaeger-ui/src/components/TracePage/TraceStatistics/generateColor.test.js
@@ -116,4 +116,16 @@ describe('generateColor', () => {
     expect(tableValue2[1].total).toBe(390);
     expect(tableValue2[1].colorToPercent).toBe('rgb(248,248,248)');
   });
+
+  it('covers percent attribute with colorToPercent=true', () => {
+    const input = [
+      { isDetail: false, percent: 75 },
+      { isDetail: false, percent: 25 },
+    ];
+
+    const output = generateColor(input, 'percent', true);
+
+    expect(output[0].colorToPercent).toBe('rgb(248,111.5,111.5)');
+    expect(output[1].colorToPercent).toBe('rgb(248,194.5,194.5)');
+  });
 });

--- a/packages/jaeger-ui/src/components/TracePage/TraceStatistics/generateDropdownValue.test.ts
+++ b/packages/jaeger-ui/src/components/TracePage/TraceStatistics/generateDropdownValue.test.ts
@@ -39,4 +39,11 @@ describe(' generateDropdownValue', () => {
     const values = generateSecondDropdownValue(transformedTrace, 'span.kind');
     expect(values).toEqual(expectValues);
   });
+
+  it('check generateSecondDropdownValue when Operation Name is selected', () => {
+    const expectValues = ['Service Name', 'span.kind', 'error', 'db.type'];
+    const values = generateSecondDropdownValue(transformedTrace, 'Operation Name');
+
+    expect(values).toEqual(expectValues);
+  });
 });


### PR DESCRIPTION
#2825

## Summary by Sourcery

Add missing unit tests for TraceStatistics utilities to improve coverage

Tests:
- Add test for generateColor to verify colorToPercent output based on percent values
- Add test for generateSecondDropdownValue to handle 'Operation Name' selection correctly