### PR TITLE
.github/workflows/s390x-build.yaml

### DIFF
--- a/.github/workflows/s390x-build.yaml
+++ b/.github/workflows/s390x-build.yaml
@@ -32,7 +32,7 @@ jobs:
             ${{ runner.os }}-buildx-
 
       - name: Build on docker
-        uses: docker/build-push-action@1dc73863535b631f98b2378be8619f83b136f4a0 # v6.17.0
+        uses: docker/build-push-action@263435318d21b8e681c14492fe198d362a7d2c83 # v6.18.0
         with:
           context: .
           push: false

--- a/package-lock.json
+++ b/package-lock.json
@@ -18343,14 +18343,14 @@
       }
     },
     "node_modules/terser": {
-      "version": "5.39.0",
-      "resolved": "https://registry.npmjs.org/terser/-/terser-5.39.0.tgz",
-      "integrity": "sha512-LBAhFyLho16harJoWMg/nZsQYgTrg5jXOn2nCYjRUcZZEdE3qa2zb8QEDRUGVZBW4rlazf2fxkg8tztybTaqWw==",
+      "version": "5.40.0",
+      "resolved": "https://registry.npmjs.org/terser/-/terser-5.40.0.tgz",
+      "integrity": "sha512-cfeKl/jjwSR5ar7d0FGmave9hFGJT8obyo0z+CrQOylLDbk7X81nPU6vq9VORa5jU30SkDnT2FXjLbR8HLP+xA==",
       "dev": true,
       "license": "BSD-2-Clause",
       "dependencies": {
         "@jridgewell/source-map": "^0.3.3",
-        "acorn": "^8.8.2",
+        "acorn": "^8.14.0",
         "commander": "^2.20.0",
         "source-map-support": "~0.5.20"
       },
@@ -19886,7 +19886,7 @@
         "memoize-one": "^6.0.0",
         "object-hash": "^3.0.0",
         "prop-types": "^15.5.10",
-        "query-string": "^9.2.0",
+        "query-string": "^9.0.0",
         "react": "^18.3.1",
         "react-circular-progressbar": "^2.1.0",
         "react-dom": "^18.3.1",
@@ -19940,7 +19940,7 @@
         "react-test-renderer": "^18.3.1",
         "rollup-plugin-visualizer": "^6.0.0",
         "sinon": "^20.0.0",
-        "terser": "^5.31.0",
+        "terser": "^5.40.0",
         "vite": "^6.0.7",
         "vite-plugin-imp": "^2.4.0"
       }


### PR DESCRIPTION
[chore(deps): update dependency terser to v5.40.0 (](https://github.com/7908837174/jaeger-ui-kallal/commit/b0de9c6142a2c5735ecf65be9d16763db901bdc3)https://github.com/jaegertracing/jaeger-ui/pull/2849[)](https://github.com/7908837174/jaeger-ui-kallal/commit/b0de9c6142a2c5735ecf65be9d16763db901bdc3) 

@[renovate-bot](https://github.com/7908837174/jaeger-ui-kallal/commits?author=renovate-bot) 
[chore(deps): update docker/build-push-action action to v6.18.0 (](https://github.com/7908837174/jaeger-ui-kallal/commit/a1ef286cdd2123303c59f8e6f4014cef0c0c8a76)https://github.com/jaegertracing/jaeger-ui/pull/2850 

@[renovate-bot](https://github.com/7908837174/jaeger-ui-kallal/commits?author=renovate-bot)

## Summary by Sourcery

Bump terser and the s390x-build CI workflow’s build-push-action to their latest versions.

CI:
- Update s390x-build workflow to use docker/build-push-action v6.18.0.

Chores:
- Upgrade terser dependency to v5.40.0.